### PR TITLE
feat: support custom change events

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ workflow configuration.
 
 **Required** The integration key that identifies the PagerDuty service the change was made to, added as a GitHub secret for the repository.
 
+### `custom-event`
+
+Custom event summary. If provided the GitHub event type is ignored and the given summary used. A link to the run is included in the change event.
+
 ## Example usage
 
 ```yaml
@@ -42,4 +46,40 @@ jobs:
         uses: PagerDuty/pagerduty-change-events-action@master
         with:
           integration-key: ${{ secrets.PAGERDUTY_CHANGE_INTEGRATION_KEY }}
+```
+
+### Custom event
+
+Custom events can for instance be used for notifying about the result of a job:
+
+```yaml
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploying the application (dummy)
+    steps:
+      - name: Dummy step
+        run: echo "Dummy deployment"
+
+  notification:
+    runs-on: ubuntu-latest
+    name: Notify PagerDuty
+    needs: [deploy]
+    if: always()
+    steps:
+      # make deploy job status available
+      # see https://github.com/marketplace/actions/workflow-status-action
+      - uses: martialonline/workflow-status@v3
+        id: check
+      - name: Create a change event
+        uses: PagerDuty/pagerduty-change-events-action@master
+        with:
+          integration-key: ${{ secrets.PAGERDUTY_CHANGE_INTEGRATION_KEY }}
+          custom-event: Deployment ${{ steps.check.outputs.status }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   integration-key:
     description: 'The integration key that identifies the service the change was made to.'
     required: true
+  custom-event:
+    description: 'Custom event summary. If provided the GitHub event type is ignored and the given summary used. A link to the run is included in the event.'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
If a custom summary is provided the existing logic is ignored and the
provided summary is used.
Also, a link to the run is added to the change event.

Thought this might be helpful also for others.

I'm not an expert in Javascript or GitHub Actions so any hints for improvements are welcome.