### PR TITLE
fix: ensure customEvent is not empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ try {
   const customEvent = core.getInput('custom-event');
   const data = github.context.payload;
 
-  if (typeof customEvent === 'string') {
+  if (typeof customEvent === 'string' && customEvent !== '') {
     // if custom event is described, prefer emitting custom event
     handleCustomEvent(customEvent, integrationKey);
   } else if (github.context.eventName === 'push') {


### PR DESCRIPTION
# What

add a `customEvent` check so that default value (`''`) is not considered as truthy 

# Why

Github actions default value is `''` 

Printing the process.env with no input given gives 
```bash
 'INPUT_INTEGRATION-KEY': '',
```

it leads to `Error: Request failed with status code 400`  as summary is empty