### PR TITLE
fix: view-run links when running from self-hosted GH

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function handleCustomEvent(summary, integrationKey) {
     },
     links: [
       {
-        href: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+        href: `https://${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
         text: "View run"
       }
     ]

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function handleCustomEvent(summary, integrationKey) {
     },
     links: [
       {
-        href: `https://${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+        href: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
         text: "View run"
       }
     ]


### PR DESCRIPTION
 - [x] Correct `view run` URL when running the actions from self-hosted Github instances.