### PR TITLE
Node.js 12 actions are deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'Custom event summary. If provided the GitHub event type is ignored and the given summary used. A link to the run is included in the event.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: PagerDuty/pagerduty-change-events-action@v1.2.0