### PR TITLE
Add custom details and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ workflow configuration.
 
 Custom event summary. If provided the GitHub event type is ignored and the given summary used. A link to the run is included in the change event.
 
+### `custom-details`
+
+Additional details about the event and affected system on a push or custom event.
+
+### `custom-link`
+
+Override default links to be shown on the alert and/or corresponding incident for a push or custom event.
+
 ## Example usage
 
 ```yaml
@@ -77,9 +85,23 @@ jobs:
       # see https://github.com/marketplace/actions/workflow-status-action
       - uses: martialonline/workflow-status@v3
         id: check
+        
       - name: Create a change event
         uses: PagerDuty/pagerduty-change-events-action@master
         with:
           integration-key: ${{ secrets.PAGERDUTY_CHANGE_INTEGRATION_KEY }}
           custom-event: Deployment ${{ steps.check.outputs.status }}
+          custom-details: |
+            {
+              "build_state": "passed",
+              "build_number": "220",
+              "run_time": "1236s"
+            }
+          custom-links: |
+            [
+              {
+                "href": "https://dashboard.com/1234",
+                "text": "View Dashboard"
+              }
+            ]
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Additional details about the event and affected system on a push or custom event.'
     required: false
   custom-links: 
-    description: 'Links to be shown on the alert and/or corresponding incident.'
+    description: 'Override default links to be shown on the alert and/or corresponding incident for a push or custom event.'
     required: false
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,12 @@ inputs:
   custom-event:
     description: 'Custom event summary. If provided the GitHub event type is ignored and the given summary used. A link to the run is included in the event.'
     required: false
+  custom-details: 
+    description: 'Additional details about the event and affected system on a push or custom event.'
+    required: false
+  custom-links: 
+    description: 'Links to be shown on the alert and/or corresponding incident.'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: 'Override default links to be shown on the alert and/or corresponding incident for a push or custom event.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ try {
   const customEvent = core.getInput('custom-event');
   const data = github.context.payload;
 
-  const customDetails = core.getInput('custom-details') ? JSON.parse(core.getInput('custom-details')) || {};
+  const customDetails = core.getInput('custom-details') ? JSON.parse(core.getInput('custom-details')) : {};
   const customLinks = core.getInput('custom-links') ? JSON.parse(core.getInput('custom-links')) : null;
 
   if (typeof customEvent === 'string' && customEvent !== '') {

--- a/index.js
+++ b/index.js
@@ -15,16 +15,16 @@ async function sendChangeEvent(changeEvent) {
   }
 }
 
-function handleCustomEvent(summary, integrationKey) {
+function handleCustomEvent(summary, customDetails, customLinks, integrationKey) {
   const changeEvent = {
     routing_key: integrationKey,
     payload: {
       summary: summary,
       source: 'GitHub',
       timestamp: (new Date()).toISOString(),
-      custom_details: {}
+      custom_details: customDetails
     },
-    links: [
+    links: customLinks || [
       {
         href: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
         text: "View run"
@@ -35,7 +35,7 @@ function handleCustomEvent(summary, integrationKey) {
   sendChangeEvent(changeEvent);
 }
 
-function handlePushEvent(data, integrationKey) {
+function handlePushEvent(data, customDetails, customLinks, integrationKey) {
   const {
     ref,
     compare: compareHref,
@@ -58,9 +58,9 @@ function handlePushEvent(data, integrationKey) {
       summary: `${senderLogin} pushed branch ${branch} from ${repoFullName}`.slice(0, 1024),
       source: 'GitHub',
       timestamp: (new Date()).toISOString(),
-      custom_details: {}
+      custom_details: customDetails
     },
-    links: [
+    links: customLinks || [
       {
         href: compareHref,
         text: 'View on GitHub'
@@ -148,11 +148,14 @@ try {
   const customEvent = core.getInput('custom-event');
   const data = github.context.payload;
 
+  const customDetails = core.getInput('custom-details') ? JSON.parse(core.getInput('custom-details')) || {};
+  const customLinks = core.getInput('custom-links') ? JSON.parse(core.getInput('custom-links')) : null;
+
   if (typeof customEvent === 'string' && customEvent !== '') {
     // if custom event is described, prefer emitting custom event
-    handleCustomEvent(customEvent, integrationKey);
+    handleCustomEvent(customEvent, customDetails, customLinks, integrationKey);
   } else if (github.context.eventName === 'push') {
-    handlePushEvent(data, integrationKey);
+    handlePushEvent(data, customDetails, customLinks, integrationKey);
   } else if (github.context.eventName === 'pull_request' && data.action === 'closed' && data.pull_request.merged) {
     handlePullRequestEvent(data, integrationKey);
   } else {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function handleCustomEvent(summary, customDetails, customLinks, integrationKey) 
     },
     links: customLinks || [
       {
-        href: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+        href: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
         text: "View run"
       }
     ]


### PR DESCRIPTION
Add custom details and links to custom event and push event.

It would be helpful to be able to pass additional information on a custom event.  Such as a release version deployed, link to our deployedment board and other dashboards, etc.