### PR TITLE
Node.js 16 actions are being deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'Custom event summary. If provided the GitHub event type is ignored and the given summary used. A link to the run is included in the event.'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Node.js 16 actions are being deprecated. For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/